### PR TITLE
Drop SHA-1, add SHA-384, SHA-512

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A commandline Java-based generator for JSON Web Keys (JWK) and JSON Private/Shar
 
 ## Standalone run
 
-To compile, run `mvn package`. This will generate a `json-web-key-generator-1.0.0-SNAPSHOT-jar-with-dependencies.jar` in the `/target` directory.
+To compile, run `mvn package`. This will generate a `json-web-key-generator-1.1.0-SNAPSHOT-jar-with-dependencies.jar` in the `/target` directory.
 
-To generate a key, run `java -jar target/json-web-key-generator-1.0.0-SNAPSHOT-jar-with-dependencies.jar -t <keytype>`. Several other arguments are defined which may be required depending on your key type:
+To generate a key, run `java -jar target/json-web-key-generator-1.1.0-SNAPSHOT-jar-with-dependencies.jar -t <keytype>`. Several other arguments are defined which may be required depending on your key type:
 
 ```
 usage: java -jar json-web-key-generator.jar -t <keyType> [options]
@@ -37,6 +37,7 @@ usage: java -jar json-web-key-generator.jar -t <keyType> [options]
                            will not be displayed to console. '-o/--output'
                            must be declared as well.
  -x,--x509                 Display keys in X509 PEM format
+ -C,--compact              Write output in compact mode.
 ```
 
 ## Docker

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ usage: java -jar json-web-key-generator.jar -t <keyType> [options]
  -i,--id <arg>             Key ID (optional), one will be generated if not
                            defined
  -g,--idGenerator <arg>    Key ID generation method (optional). Can be one
-                           of: date, timestamp, sha256, sha1, none. If
+                           of: date, timestamp, sha256, sha384, sha512, none. If
                            omitted, generator method defaults to
                            'timestamp'.
  -I,--noGenerateId         <deprecated> Don't generate a Key ID.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>org.mitre</groupId>
 	<artifactId>json-web-key-generator</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>json-web-key-generator</name>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,18 @@
 		<version>7</version>
 	</parent>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.junit</groupId>
+				<artifactId>junit-bom</artifactId>
+				<version>5.10.2</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+	
 	<build>
 		<pluginManagement>
 			<plugins>
@@ -76,9 +88,8 @@
 	</build>
 	<dependencies>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>3.8.1</version>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -89,12 +100,12 @@
 		<dependency>
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
-			<version>1.4</version>
+			<version>1.8.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>18.0</version>
+			<version>33.2.1-jre</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>

--- a/src/main/java/org/mitre/jose/jwk/ECKeyMaker.java
+++ b/src/main/java/org/mitre/jose/jwk/ECKeyMaker.java
@@ -62,11 +62,7 @@ public class ECKeyMaker {
                     .build();
 
             return ecKey;
-        } catch (InvalidAlgorithmParameterException e) {
-            e.printStackTrace();
-            return null;
-        } catch (NoSuchAlgorithmException e) {
-            // TODO Auto-generated catch block
+        } catch (InvalidAlgorithmParameterException | NoSuchAlgorithmException e) {
             e.printStackTrace();
             return null;
         }

--- a/src/main/java/org/mitre/jose/jwk/KeyIdGenerator.java
+++ b/src/main/java/org/mitre/jose/jwk/KeyIdGenerator.java
@@ -10,7 +10,6 @@ import java.util.function.Function;
 import com.google.common.hash.Hashing;
 import com.nimbusds.jose.jwk.JWKParameterNames;
 import com.nimbusds.jose.jwk.KeyUse;
-import com.nimbusds.jose.util.Base64;
 import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jose.util.JSONObjectUtils;
 import com.nimbusds.jose.util.StandardCharset;
@@ -21,7 +20,6 @@ import com.nimbusds.jose.util.StandardCharset;
  */
 // KeyID generator functions
 public class KeyIdGenerator {
-    private static final String PUBLIC_KEY = "pub_key";
 
     public static KeyIdGenerator TIMESTAMP = new KeyIdGenerator("timestamp", (params) -> {
         KeyUse use = (KeyUse) params.get(JWKParameterNames.PUBLIC_KEY_USE);
@@ -41,11 +39,17 @@ public class KeyIdGenerator {
 		return Base64URL.encode(bytes).toString();
 	});
 
-    public static KeyIdGenerator SHA1 = new KeyIdGenerator("sha1", (params) -> {
+    public static KeyIdGenerator SHA384 = new KeyIdGenerator("sha384", (params) -> {
         final String json = JSONObjectUtils.toJSONString(params);
-        byte[] bytes = Hashing.sha1().hashBytes(json.getBytes(StandardCharset.UTF_8)).asBytes();
-		return Base64.encode(bytes).toString();
-	});
+        byte[] bytes = Hashing.sha384().hashBytes(json.getBytes(StandardCharset.UTF_8)).asBytes();
+        return Base64URL.encode(bytes).toString();
+    });
+
+    public static KeyIdGenerator SHA512 = new KeyIdGenerator("sha512", (params) -> {
+        final String json = JSONObjectUtils.toJSONString(params);
+        byte[] bytes = Hashing.sha512().hashBytes(json.getBytes(StandardCharset.UTF_8)).asBytes();
+        return Base64URL.encode(bytes).toString();
+    });
 
     public static KeyIdGenerator NONE = new KeyIdGenerator("none", (params) -> {
 		return null;
@@ -68,7 +72,7 @@ public class KeyIdGenerator {
 	}
 
 	public static List<KeyIdGenerator> values() {
-		return List.of(DATE, TIMESTAMP, SHA256, SHA1, NONE);
+        return List.of(DATE, TIMESTAMP, SHA256, SHA384, SHA512, NONE);
 	}
 
 	public static KeyIdGenerator get(String name) {

--- a/src/main/java/org/mitre/jose/jwk/OKPKeyMaker.java
+++ b/src/main/java/org/mitre/jose/jwk/OKPKeyMaker.java
@@ -12,7 +12,6 @@ import org.bouncycastle.asn1.ASN1Sequence;
 
 import com.nimbusds.jose.Algorithm;
 import com.nimbusds.jose.jwk.Curve;
-import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKParameterNames;
 import com.nimbusds.jose.jwk.KeyType;
 import com.nimbusds.jose.jwk.KeyUse;
@@ -32,7 +31,7 @@ public class OKPKeyMaker {
 	 * @param kid
 	 * @return
 	 */
-	public static JWK make(Curve keyCurve, KeyUse keyUse, Algorithm keyAlg, KeyIdGenerator kid) {
+    public static OctetKeyPair make(Curve keyCurve, KeyUse keyUse, Algorithm keyAlg, KeyIdGenerator kid) {
 
 		try {
 
@@ -103,7 +102,6 @@ public class OKPKeyMaker {
 			return jwk;
 
 		} catch (NoSuchAlgorithmException | IOException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 			return null;
 		}

--- a/src/main/java/org/mitre/jose/jwk/RSAKeyMaker.java
+++ b/src/main/java/org/mitre/jose/jwk/RSAKeyMaker.java
@@ -56,7 +56,6 @@ public class RSAKeyMaker {
 
             return rsaKey;
         } catch (NoSuchAlgorithmException e) {
-            // TODO Auto-generated catch block
             e.printStackTrace();
             return null;
         }

--- a/src/test/java/org/mitre/jose/jwk/ECKeyMakerTest.java
+++ b/src/test/java/org/mitre/jose/jwk/ECKeyMakerTest.java
@@ -1,0 +1,45 @@
+package org.mitre.jose.jwk;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.KeyUse;
+
+public class ECKeyMakerTest {
+
+    @Test
+    void sha256() throws JOSEException {
+        KeyIdGenerator kidGenerator = KeyIdGenerator.SHA256;
+        String hashAlg = "SHA-256";
+        ECKey key = ECKeyMaker.make(Curve.P_256, KeyUse.SIGNATURE, JWSAlgorithm.ES256, kidGenerator);
+        ECKey ecKey = new ECKey.Builder(key).keyIDFromThumbprint(hashAlg).build();
+        assertEquals(key.getKeyID(), ecKey.getKeyID(),
+                "kid should be same as " + hashAlg + " hashed value from method keyIDFromThumbprint");
+    }
+
+    @Test
+    void sha384() throws JOSEException {
+        KeyIdGenerator kidGenerator = KeyIdGenerator.SHA384;
+        String hashAlg = "SHA-384";
+        ECKey key = ECKeyMaker.make(Curve.P_256, KeyUse.SIGNATURE, JWSAlgorithm.ES256, kidGenerator);
+        ECKey ecKey = new ECKey.Builder(key).keyIDFromThumbprint(hashAlg).build();
+        assertEquals(key.getKeyID(), ecKey.getKeyID(),
+                "kid should be same as " + hashAlg + " hashed value from method keyIDFromThumbprint");
+    }
+
+    @Test
+    void sha512() throws JOSEException {
+        KeyIdGenerator kidGenerator = KeyIdGenerator.SHA512;
+        String hashAlg = "SHA-512";
+        ECKey key = ECKeyMaker.make(Curve.P_256, KeyUse.SIGNATURE, JWSAlgorithm.ES256, kidGenerator);
+        ECKey ecKey = new ECKey.Builder(key).keyIDFromThumbprint(hashAlg).build();
+        assertEquals(key.getKeyID(), ecKey.getKeyID(),
+                "kid should be same as " + hashAlg + " hashed value from method keyIDFromThumbprint");
+    }
+
+}

--- a/src/test/java/org/mitre/jose/jwk/OKPKeyMakerTest.java
+++ b/src/test/java/org/mitre/jose/jwk/OKPKeyMakerTest.java
@@ -1,0 +1,45 @@
+package org.mitre.jose.jwk;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.OctetKeyPair;
+
+public class OKPKeyMakerTest {
+
+    @Test
+    void sha256() throws JOSEException {
+        KeyIdGenerator kidGenerator = KeyIdGenerator.SHA256;
+        String hashAlg = "SHA-256";
+        OctetKeyPair key = OKPKeyMaker.make(Curve.Ed25519, KeyUse.SIGNATURE, JWSAlgorithm.EdDSA, kidGenerator);
+        OctetKeyPair ecKey = new OctetKeyPair.Builder(key).keyIDFromThumbprint(hashAlg).build();
+        assertEquals(key.getKeyID(), ecKey.getKeyID(),
+                "kid should be same as " + hashAlg + " hashed value from method keyIDFromThumbprint");
+    }
+
+    @Test
+    void sha384() throws JOSEException {
+        KeyIdGenerator kidGenerator = KeyIdGenerator.SHA384;
+        String hashAlg = "SHA-384";
+        OctetKeyPair key = OKPKeyMaker.make(Curve.Ed25519, KeyUse.SIGNATURE, JWSAlgorithm.EdDSA, kidGenerator);
+        OctetKeyPair ecKey = new OctetKeyPair.Builder(key).keyIDFromThumbprint(hashAlg).build();
+        assertEquals(key.getKeyID(), ecKey.getKeyID(),
+                "kid should be same as " + hashAlg + " hashed value from method keyIDFromThumbprint");
+    }
+
+    @Test
+    void sha512() throws JOSEException {
+        KeyIdGenerator kidGenerator = KeyIdGenerator.SHA512;
+        String hashAlg = "SHA-512";
+        OctetKeyPair key = OKPKeyMaker.make(Curve.Ed25519, KeyUse.SIGNATURE, JWSAlgorithm.EdDSA, kidGenerator);
+        OctetKeyPair ecKey = new OctetKeyPair.Builder(key).keyIDFromThumbprint(hashAlg).build();
+        assertEquals(key.getKeyID(), ecKey.getKeyID(),
+                "kid should be same as " + hashAlg + " hashed value from method keyIDFromThumbprint");
+    }
+
+}

--- a/src/test/java/org/mitre/jose/jwk/OctetSequenceKeyMakerTest.java
+++ b/src/test/java/org/mitre/jose/jwk/OctetSequenceKeyMakerTest.java
@@ -1,0 +1,44 @@
+package org.mitre.jose.jwk;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.OctetSequenceKey;
+
+public class OctetSequenceKeyMakerTest {
+
+    @Test
+    void sha256() throws JOSEException {
+        KeyIdGenerator kidGenerator = KeyIdGenerator.SHA256;
+        String hashAlg = "SHA-256";
+        OctetSequenceKey key = OctetSequenceKeyMaker.make(2048, KeyUse.SIGNATURE, JWSAlgorithm.HS256, kidGenerator);
+        OctetSequenceKey octKey = new OctetSequenceKey.Builder(key).keyIDFromThumbprint(hashAlg).build();
+        assertEquals(key.getKeyID(), octKey.getKeyID(),
+                "kid should be same as " + hashAlg + " hashed value from method keyIDFromThumbprint");
+    }
+
+    @Test
+    void sha384() throws JOSEException {
+        KeyIdGenerator kidGenerator = KeyIdGenerator.SHA384;
+        String hashAlg = "SHA-384";
+        OctetSequenceKey key = OctetSequenceKeyMaker.make(2048, KeyUse.SIGNATURE, JWSAlgorithm.HS256, kidGenerator);
+        OctetSequenceKey octKey = new OctetSequenceKey.Builder(key).keyIDFromThumbprint(hashAlg).build();
+        assertEquals(key.getKeyID(), octKey.getKeyID(),
+                "kid should be same as " + hashAlg + " hashed value from method keyIDFromThumbprint");
+    }
+
+    @Test
+    void sha512() throws JOSEException {
+        KeyIdGenerator kidGenerator = KeyIdGenerator.SHA512;
+        String hashAlg = "SHA-512";
+        OctetSequenceKey key = OctetSequenceKeyMaker.make(2048, KeyUse.SIGNATURE, JWSAlgorithm.HS256, kidGenerator);
+        OctetSequenceKey octKey = new OctetSequenceKey.Builder(key).keyIDFromThumbprint(hashAlg).build();
+        assertEquals(key.getKeyID(), octKey.getKeyID(),
+                "kid should be same as " + hashAlg + " hashed value from method keyIDFromThumbprint");
+    }
+
+}

--- a/src/test/java/org/mitre/jose/jwk/RSAKeyMakerTest.java
+++ b/src/test/java/org/mitre/jose/jwk/RSAKeyMakerTest.java
@@ -1,0 +1,44 @@
+package org.mitre.jose.jwk;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+
+public class RSAKeyMakerTest {
+
+    @Test
+    void sha256() throws JOSEException {
+        KeyIdGenerator kidGenerator = KeyIdGenerator.SHA256;
+        String hashAlg = "SHA-256";
+        RSAKey key = RSAKeyMaker.make(2048, KeyUse.SIGNATURE, JWSAlgorithm.RS256, kidGenerator);
+        RSAKey rsaKey = new RSAKey.Builder(key).keyIDFromThumbprint(hashAlg).build();
+        assertEquals(key.getKeyID(), rsaKey.getKeyID(),
+                "kid should be same as " + hashAlg + " hashed value from method keyIDFromThumbprint");
+    }
+
+    @Test
+    void sha384() throws JOSEException {
+        KeyIdGenerator kidGenerator = KeyIdGenerator.SHA384;
+        String hashAlg = "SHA-384";
+        RSAKey key = RSAKeyMaker.make(2048, KeyUse.SIGNATURE, JWSAlgorithm.RS256, kidGenerator);
+        RSAKey rsaKey = new RSAKey.Builder(key).keyIDFromThumbprint(hashAlg).build();
+        assertEquals(key.getKeyID(), rsaKey.getKeyID(),
+                "kid should be same as " + hashAlg + " hashed value from method keyIDFromThumbprint");
+    }
+
+    @Test
+    void sha512() throws JOSEException {
+        KeyIdGenerator kidGenerator = KeyIdGenerator.SHA512;
+        String hashAlg = "SHA-512";
+        RSAKey key = RSAKeyMaker.make(2048, KeyUse.SIGNATURE, JWSAlgorithm.RS256, kidGenerator);
+        RSAKey rsaKey = new RSAKey.Builder(key).keyIDFromThumbprint(hashAlg).build();
+        assertEquals(key.getKeyID(), rsaKey.getKeyID(),
+                "kid should be same as " + hashAlg + " hashed value from method keyIDFromThumbprint");
+    }
+
+}


### PR DESCRIPTION
**[Changes]**

- kid generator: drop SHA-1, add SHA-384, SHA512
- option: add compact option to write output in compact mode
- test: add JUnit test cases
- OKPKeyMaker: change return type from JWK to OctetKeyPair 
- deps: bump JUnit 5.10.2, commons-cli 1.8.0, guava 33.2.1-jre